### PR TITLE
Update km_smart_proximity.cfg

### DIFF
--- a/GameData/SmartParts/Parts/Smart-Controller/km_smart_proximity.cfg
+++ b/GameData/SmartParts/Parts/Smart-Controller/km_smart_proximity.cfg
@@ -26,7 +26,7 @@ PART
 	title = PROX-Pro Proximity Sensor
 	manufacturer = Orbital Intelligence
 	description = Fires an event if the sensor detects another craft with a proximity sensor on the same channel
-	tag = control proximity
+	tags = control proximity
 	
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 0,1,0,0,0


### PR DESCRIPTION
tag > tags
Eliminates: PartLoader Warning: Variable tag not found in Part
(Eases my CDO)